### PR TITLE
Scroll down when the last row in the current viewport is reached.

### DIFF
--- a/Microsoft.Dynamics.Nav.LoadTest/OrderProcessorScenarios.cs
+++ b/Microsoft.Dynamics.Nav.LoadTest/OrderProcessorScenarios.cs
@@ -157,8 +157,8 @@ namespace Microsoft.Dynamics.Nav.LoadTest
 
             userContext.ValidateForm(newSalesOrderPage);
 
-            // Add a random number of lines between 2 and 5
-            int noOfLines = SafeRandom.GetRandomNext(2, 6);
+            // Add a random number of lines between 2 and 25
+            int noOfLines = SafeRandom.GetRandomNext(2, 25);
             for (int line = 0; line < noOfLines; line++)
             {
                 AddSalesOrderLine(userContext, newSalesOrderPage, line);
@@ -198,10 +198,18 @@ namespace Microsoft.Dynamics.Nav.LoadTest
             }
         }
 
-        private void AddSalesOrderLine(UserContext userContext, ClientLogicalForm newSalesOrderPage, int line)
+        private void AddSalesOrderLine(UserContext userContext, ClientLogicalForm newSalesOrderPage, int index)
         {
-            // Get Line
-            var itemsLine = newSalesOrderPage.Repeater().DefaultViewport[line];
+            var repeater = newSalesOrderPage.Repeater();
+            var rowCount = repeater.Offset + repeater.DefaultViewport.Count;
+            if (index >= rowCount)
+            {
+                // scroll to the next viewport
+                userContext.InvokeInteraction(new ScrollRepeaterInteraction(repeater, 1));
+            }
+
+            var rowIndex = (index % repeater.DefaultViewport.Count);
+            var itemsLine = repeater.DefaultViewport[rowIndex];
 
             // Activate Type field
             itemsLine.Control("Type").Activate();


### PR DESCRIPTION
FIxes the issue when adding more than 10 lines to an order. Scrolls the lines repeater viewport.