### PR TITLE
Feature/await duration and caption matching

### DIFF
--- a/Microsoft.Dynamics.Nav.TestUtilities/TestScenario.cs
+++ b/Microsoft.Dynamics.Nav.TestUtilities/TestScenario.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Dynamics.Nav.TestUtilities
             catch (Exception)
             {
                 // if error occurs we close the session and don't return to the pool
+                userContext.WaitForReady();
                 CloseSession(userContext, testContext);
                 throw;
             }

--- a/Microsoft.Dynamics.Nav.UserSession/ClientLogicalControlExtensions.cs
+++ b/Microsoft.Dynamics.Nav.UserSession/ClientLogicalControlExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Dynamics.Nav.UserSession
                 rootForm.Session.InvokeInteraction(
                     new InvokeActionInteraction(control, SystemAction.Lookup)));
         }
-
+        
         /// <summary>Save a value for the control.</summary>
         /// <param name="control">The control.</param>
         /// <param name="newValue">The new Value.</param>
@@ -85,7 +85,10 @@ namespace Microsoft.Dynamics.Nav.UserSession
         {
             try
             {
-                return control.ContainedControls.OfType<ClientActionControl>().First(c => c.Caption.Replace("&", "").EndsWith(actionCaption));
+                return control
+                    .ContainedControls
+                    .OfType<ClientActionControl>()
+                    .First(c => c.HasCaption(actionCaption));
             }
             catch (InvalidOperationException exception)
             {
@@ -107,13 +110,20 @@ namespace Microsoft.Dynamics.Nav.UserSession
         {
             try
             {
-                return control.ContainedControls.First(c => c.Caption.Replace("&", "").EndsWith(controlCaption));
+                return control
+                    .ContainedControls
+                    .First(c => c.HasCaption(controlCaption));
             }
             catch (InvalidOperationException exception)
             {
                 control.WriteControlCaptions<ClientLogicalControl>();
                 throw new ArgumentOutOfRangeException(string.Format("Could not find a control with caption {0}",controlCaption), exception);
             }
+        }
+
+        private static bool HasCaption(this ClientLogicalControl control, string caption)
+        {
+            return control.Caption.Replace("&", "").Equals(caption);
         }
     }
 }


### PR DESCRIPTION
This PR contains 2 fixes for the framework:

1. Do an exact match on control and action captions instead of startswith to avoid incorrect matches.
2. Stop using WaitForever in AwaitReady so that tests timeout faster. Uses specific await durations instead.